### PR TITLE
Add `lastEventId` and `url` in events with defined type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,8 @@ export interface ErrorEvent {
 export interface CustomEvent<E extends string> {
   type: E;
   data: string | null;
+  lastEventId: string | null;
+  url: string;
 }
 
 export interface ExceptionEvent {

--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -183,23 +183,15 @@ class EventSource {
         this.lastEventId = null;
       } else if (line === '') {
         if (data.length > 0) {
-          if (this.eventType !== undefined) {
-            const event = {
-              type: this.eventType,
-              data: data.join('\n'),
-            };
+          const eventType = this.eventType || 'message'
+          const event = {
+            type: eventType,
+            data: data.join("\n"),
+            url: this.url,
+            lastEventId: this.lastEventId,
+          };
 
-            this.dispatch(this.eventType, event);
-          } else {
-            const event = {
-              type: 'message',
-              data: data.join('\n'),
-              url: this.url,
-              lastEventId: this.lastEventId,
-            };
-
-            this.dispatch('message', event);
-          }
+          this.dispatch(eventType, event);
 
           data = [];
           this.eventType = undefined;


### PR DESCRIPTION
When a known event type was coming from the server, the `lastEventId` and the `url` were not added into the dispatched event.

This adds `lastEventId` and the `url` in all `MessageEvents`.
Additionally, a small refactoring was done to avoid the `if` altogether.