### PR TITLE
fix first event is not handled

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -161,7 +161,9 @@ class EventSource {
 
   _handleEvent(response) {
     const parts = response.substr(this.lastIndexProcessed).split('\n');
-    this.lastIndexProcessed = response.lastIndexOf('\n\n') + 2;
+    if (response.includes('\n\n')) {
+      this.lastIndexProcessed = response.lastIndexOf('\n\n') + 2;
+    }
     let data = [];
     let retry = 0;
     let line = '';


### PR DESCRIPTION
I was struggling that the first event was not handled. 
That was because the first response that got into the function _handleEvent(response) was just "date:" (Thats all. Has no "\n\n")
Therefore response.lastIndexOf('\n\n') returns -1 and when real event got into the method his response.substr(this.lastIndexProcessed) was like "ata: { // data // }" and data didnt get into the function dispatch