### PR TITLE
Use Maps and Sets to store event listeners. This is more performant t…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,11 @@ export type EventSourceListener<E extends string = never> = (
 ) => void;
 
 declare class EventSource<E extends string = never> {
+  static ERROR = -1;
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  status: number;
   constructor(url: URL | string, options?: EventSourceOptions);
   open(): void;
   close(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,10 +60,10 @@ export type EventSourceListener<E extends string = never> = (
 ) => void;
 
 declare class EventSource<E extends string = never> {
-  static ERROR = -1;
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSED = 2;
+  static ERROR: -1;
+  static CONNECTING: 0;
+  static OPEN: 1;
+  static CLOSED: 2;
   status: number;
   constructor(url: URL | string, options?: EventSourceOptions);
   open(): void;


### PR DESCRIPTION
* Use Maps and Sets to store event listeners. This is more performant then using Objects and Arrays

* Made statuses static and added EventSource.status as public to EventSource type. Users may need it to test EventSource instance.