### PR TITLE
Update EventSource.js

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -177,9 +177,11 @@ class EventSource {
     const parts = response.substr(this.lastIndexProcessed).split('\n');
     
     const indexOfDoubleNewline = response.lastIndexOf('\n\n');
-    if (indexOfDoubleNewline != -1) {
-      this.lastIndexProcessed = indexOfDoubleNewline + 2;
+    if (indexOfDoubleNewline < 0) {
+      return;
     }
+
+    this.lastIndexProcessed = indexOfDoubleNewline + 2;
     
     let data = [];
     let retry = 0;


### PR DESCRIPTION
Fix to only handle events once an empty line is present.

When events are sent as multipart messages `onreadystatechange` will be called multiple times. Since `response.substr(this.lastIndexProcessed).split('\n')` also return an empty string with only 1 newline, dispatch will also be called multiple time (e.g. `"event: add\n data: 4\n".split('\n')` will give `[ "event: add", " data: 4", "" ]`). This fix will check if indeed an empty line is present before processing the event.
