### PR TITLE
Fix infinite call loop after close event dispatch

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -262,13 +262,15 @@ class EventSource {
   }
 
   close() {
-    this.status = this.CLOSED;
+    if (this.status !== this.CLOSED) {
+      this.status = this.CLOSED;
+      this.dispatch('close', { type: 'close' });
+    }
+
     clearTimeout(this._pollTimer);
     if (this._xhr) {
       this._xhr.abort();
     }
-
-    this.dispatch('close', { type: 'close' });
   }
 }
 


### PR DESCRIPTION
In the current version, calling `es.close()` from the close event handler results in an infinite call loop (es.close() triggers the close handler and the close handler calls es.close() again). This eventually leads to a `Maximum call stack size exceeded` error being thrown by React Native.

```ts
es.addEventListener('close', () => {
    es.close();
});
```

This PR fixes that problem.

Surfaced in https://github.com/binaryminds/react-native-sse/issues/37#issuecomment-1948048720