### PR TITLE
Fix some events getting dispatched twice when double newline is missing at the end

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -174,13 +174,15 @@ class EventSource {
   }
 
   _handleEvent(response) {
-    const parts = response.substr(this.lastIndexProcessed).split('\n');
-    
-    const indexOfDoubleNewline = response.lastIndexOf('\n\n');
-    if (indexOfDoubleNewline != -1) {
-      this.lastIndexProcessed = indexOfDoubleNewline + 2;
+    const indexOfDoubleNewline = this._getLastDoubleNewlineIndex(response);
+
+    if (indexOfDoubleNewline <= this.lastIndexProcessed) {
+      return;
     }
-    
+
+    const parts = response.substring(this.lastIndexProcessed, indexOfDoubleNewline).split('\n');
+    this.lastIndexProcessed = indexOfDoubleNewline;
+
     let data = [];
     let retry = 0;
     let line = '';
@@ -217,6 +219,14 @@ class EventSource {
         }
       }
     }
+  }
+
+  _getLastDoubleNewlineIndex(response) {
+    const lastIndex = response.lastIndexOf('\n\n');
+    if (lastIndex === -1) {
+      return -1;
+    }
+    return lastIndex + 2;
   }
 
   addEventListener(type, listener) {


### PR DESCRIPTION
As surfaced in #42, react-native-sse currently dispatches the same event twice when there is no extra newline at the end of the response text. For example, here is what currently happens for a given response text:

response text #&#8203;1: `data: MESSAGE ONE\n\ndata: MESSAGE TWO\n` <-- note that there is only one `\n` here
results in parsed lines `[ "data: MESSAGE ONE", "", "data: MESSAGE TWO", "" ]`
so the events "MESSAGE ONE" and "MESSAGE TWO" both get dispatched, and `lastIndexProcessed` is set to the index of the double newline `\n\n` which is 19. However, the actual length of the response text is 37.

response text #&#8203;2: `data: MESSAGE ONE\n\ndata: MESSAGE TWO\n\ndata: MESSAGE THREE\n\ndata: MESSAGE FOUR\n`
starting at index 19, this gives parsed lines `[ "data: MESSAGE TWO", "", "data: MESSAGE THREE", "", "data: MESSAGE FOUR", "" ]`
so the event "MESSAGE TWO" gets dispatched **again**, "MESSAGE THREE" and "MESSAGE FOUR" also get dispatched, and `lastIndexProcessed` is set to 59. However, the actual length of the response text is 78.

And it continues like this... always dispatching the last event from the previous chunk twice.

This PR fixes that problem. My solution is inspired by #39 by @GidoHakvoort, but it avoids some shortcomings and problems of that implementation.

With these changes, react-native-sse will now always only look at the chunk of the response from the `lastIndexProcessed` till the last double newline found in the response text. Afterwards it sets `lastIndexProcessed` to the index of that double newline, so the next iteration starts there, and so on.

Fixes #42.
Closes #39.