### PR TITLE
Fix greedy regex

### DIFF
--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -214,7 +214,7 @@ class EventSource {
           this.interval = retry;
         }
       } else if (line.startsWith('data')) {
-        data.push(line.replace(/data:?\s*/, ''));
+        data.push(line.replace(/data:?\s/, ''));
       } else if (line.startsWith('id')) {
         id = line.replace(/id:?\s*/, '');
         if (id !== '') {


### PR DESCRIPTION
When processing an event right now, if a SSE event starts with a space or is just made up of space characters, the regex filtering `data: ` will remove all of the spaces before it finds a non-space character.