### PR TITLE
Add `done` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ es.addEventListener("close", (event) => {
 ### Done vs Close
 
 `done` events will fire when server closes the connection.
-Reconnections will occur indefinitely, unless this behavior is disabled.
+By default, the client will automatically reconnect when this happens.
+You can disable reconnections by setting the `pollingInterval` option to `0`.
 `close` events will fire when the connection is terminated by the client, using `.close()`.
 
 ### Headers and params

--- a/README.md
+++ b/README.md
@@ -51,10 +51,22 @@ es.addEventListener("error", (event) => {
   }
 });
 
+es.addEventListener("done", (event) => {
+  console.log("Done SSE connection.");
+});
+
 es.addEventListener("close", (event) => {
   console.log("Close SSE connection.");
 });
 ```
+
+### Done vs Close
+
+`done` events will fire when server closes the connection.
+Reconnections will occur indefinitely, unless this behavior is disabled.
+`close` events will fire when the connection is terminated by the client, using `.close()`.
+
+### Headers and params
 
 If you want to use Bearer token and/or topics, look at this example (TypeScript):
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export type BuiltInEventType = 'open' | 'message' | 'error' | 'close';
+export type BuiltInEventType = 'open' | 'message' | 'error' | 'done' | 'close';
 export type EventType<E extends string = never> = E | BuiltInEventType;
 
 export interface MessageEvent {
@@ -10,6 +10,10 @@ export interface MessageEvent {
 
 export interface OpenEvent {
   type: 'open';
+}
+
+export interface DoneEvent {
+  type: 'done';
 }
 
 export interface CloseEvent {
@@ -55,6 +59,7 @@ export interface EventSourceOptions {
 type BuiltInEventMap = {
   'message': MessageEvent,
   'open': OpenEvent,
+  'done': DoneEvent,
   'close': CloseEvent,
   'error': ErrorEvent | TimeoutEvent | ExceptionEvent,
 };

--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -24,6 +24,7 @@ class EventSource {
       open: [],
       message: [],
       error: [],
+      done: [],
       close: [],
     };
 
@@ -115,6 +116,7 @@ class EventSource {
           this._handleEvent(xhr.responseText || '');
 
           if (xhr.readyState === XMLHttpRequest.DONE) {
+            this.dispatch('done', { type: 'done' });
             this._logDebug('[EventSource][onreadystatechange][DONE] Operation done.');
             this._pollAgain(this.interval, false);
           }

--- a/src/EventSource.js
+++ b/src/EventSource.js
@@ -116,9 +116,9 @@ class EventSource {
           this._handleEvent(xhr.responseText || '');
 
           if (xhr.readyState === XMLHttpRequest.DONE) {
-            this.dispatch('done', { type: 'done' });
             this._logDebug('[EventSource][onreadystatechange][DONE] Operation done.');
             this._pollAgain(this.interval, false);
+            this.dispatch('done', { type: 'done' });
           }
         } else if (xhr.status !== 0) {
           this.status = this.ERROR;


### PR DESCRIPTION
See my original issue https://github.com/binaryminds/react-native-sse/issues/56 for some background.

Currently the library only supports `close` events, which fire when the connection is closed from the **client** side. An additional event for tracking **server** side closing of the connection would be useful. This PR adds a `done` event to do that. Luckily most of the plumbing is already there, so it was easy to hook up the new event. As far as naming goes, I just matched the state name like most other events seem to do. It still might be a little confusing, so I added some text to the README.